### PR TITLE
handle big numbers

### DIFF
--- a/sessionstorage.go
+++ b/sessionstorage.go
@@ -198,32 +198,48 @@ func SessionStorageRecordToJson(r SessionStorageRecord) (string, error) {
 	out := []byte{}
 
 	if validJson {
+		// Use a custom decoder to handle large numbers as strings
+		d := json.NewDecoder(bytes.NewReader(b))
+		d.UseNumber() // This makes the decoder use json.Number for numbers
 		var v interface{}
-		err := json.Unmarshal(b, &v)
+		err := d.Decode(&v)
 		if err != nil {
 			return "", fmt.Errorf("failed to unmarshal supposedly valid JSON: %w", err)
 		}
 
 		mime = "application/json"
 
-		switch v.(type) {
-		case float64:
+		switch val := v.(type) {
+		case json.Number:
 			jsonType = "number"
+			// Check if the number might be too large for float64
+			_, err := val.Float64()
+			if err != nil {
+				// If it can't be converted to float64, treat it as a string in the output
+				strVal := fmt.Sprintf("\"%s\"", val.String())
+				out = []byte(strVal)
+			} else {
+				out = b
+			}
 		case string:
 			jsonType = "string"
+			out = b
 		case bool:
 			jsonType = "boolean"
+			out = b
 		case []interface{}:
 			jsonType = "array"
+			out = b
 		case map[string]interface{}:
 			jsonType = "object"
+			out = b
 		case nil:
 			jsonType = "null"
+			out = b
 		default:
 			jsonType = ""
+			out = b
 		}
-
-		out = b
 	} else {
 		quoted := strconv.Quote(r.Decoded)
 		if json.Valid([]byte(quoted)) {


### PR DESCRIPTION
ran into an error where it complained that the non-quoted string `7349e8r3489734589764` couldn't fit into float64

```
Error converting record to JSON: failed to unmarshal supposedly valid JSON: json: cannot unmarshal number 7349e8r3489734589764 into Go value of type float64
```

now we just treat as string when that happens